### PR TITLE
fix bug in get_order_by_order_number

### DIFF
--- a/controllers.py
+++ b/controllers.py
@@ -54,7 +54,7 @@ def get_order_by_order_number(order_number):
         order_dict = {}
         order_dict['order_number'] = order_obj.order_number
         order_dict['usa_state'] = order_obj.usa_state
-        order_dict['office_code'] = order_obj.office_code
+        order_dict['home_office_code'] = order_obj.home_office_code
         order_dict['uuid'] = order_obj.uuid
         return {"orders": [order_dict]}
 


### PR DESCRIPTION
With the current versions of the frontend and backend I was not able to successfully search by order number. That's because the backend was still looking for "office_code" where it looks like everything else has been changed to "home_office_code." I'm not sure if this is fixed in a pending PR---if so, feel free to ignore this one--but this is what it took on my end to get search up and running again!