### PR TITLE
init orders table with 10 random orders

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -1,48 +1,60 @@
 from typing import NamedTuple
-import click 
+import click
 from flask.cli import with_appcontext
-from flask import current_app, g 
+from flask import current_app, g
 from config import db
 import json
 
 from initial_data.init_office_table import init_office_table
-from initial_data.init_user_table import init_user_table_state_users, init_user_table_fed_users
+from initial_data.init_user_table import (
+    init_user_table_state_users,
+    init_user_table_fed_users,
+)
 from initial_data.init_status_table import init_status_table
+from initial_data.init_orders_table import init_orders_table
+
 
 def close_db(e=None):
-    db = g.pop('db', None)
+    db = g.pop("db", None)
 
     if db is not None:
         db.close()
 
+
 def init_db():
     # imports are inside, otherwise we get circular import during testing
-    with open('./initial_data/office_codes.json',) as office_codes_json:
+    with open(
+        "./initial_data/office_codes.json",
+    ) as office_codes_json:
         office_codes_list = json.load(office_codes_json)
-    
-    with open('./initial_data/users.json') as users_json:
+
+    with open("./initial_data/users.json") as users_json:
         users_list = json.load(users_json)
-  
-    with open('./initial_data/statuses.json') as statuses_json:
+
+    with open("./initial_data/statuses.json") as statuses_json:
         statuses_list = json.load(statuses_json)
 
     # add FED and state offices to office table
-    init_office_table(office_codes_list,db)  
+    init_office_table(office_codes_list, db)
     # add state office users to user table
-    init_user_table_state_users(office_codes_list,db)
+    init_user_table_state_users(office_codes_list, db)
     # add fed office users to user table
-    init_user_table_fed_users(users_list,db)
+    init_user_table_fed_users(users_list, db)
     # add flag statuses to status table
-    init_status_table(statuses_list,db)
+    init_status_table(statuses_list, db)
+    # initialize orders table with fake orders--REMOVE WHEN PRODUCTION READY
+    init_orders_table(office_codes_list, db)
 
     db.session.commit()
- 
-@click.command('init-db')
+
+
+@click.command("init-db")
 @with_appcontext
 def init_db_command():
     """Clear the existing data and create new tables."""
     init_db()
-    click.echo('Initialized the database.')
+    click.echo("Initialized the database.")
+
 
 def init_app(app):
     app.teardown_appcontext(close_db)

--- a/initial_data/init_orders_table.py
+++ b/initial_data/init_orders_table.py
@@ -1,0 +1,24 @@
+import uuid
+import random
+
+#  for state_offices in office_codes_list:
+#         usa_state = state_offices["usa_state"]
+#         for office_code in state_offices["office_code"]:
+
+
+def init_orders_table(office_codes_list, db):
+
+    from models import OrderModel
+
+    for x in range(10):
+        order_number = x + 1
+        theUuid = str(uuid.uuid4())
+        usa_state_object = random.choice(office_codes_list)
+        usa_state = usa_state_object.get("usa_state")
+        order_status = random.randint(1, 10)
+        home_office_code = random.choice(usa_state_object.get("office_code"))
+
+        order_ = OrderModel(
+            theUuid, usa_state, order_number, home_office_code, order_status
+        )
+        db.session.add(order_)


### PR DESCRIPTION
The restart.sh script now creates 10 random fake orders to seed the DB with, so that if the DB has to be restarted, devs aren't starting from scratch!

Currently the script just pulls all the states and then chooses randomly one of them. I don't know what would happen if it chooses "FED" as a state. I left this as-is because I can't remember what we had said about whether orders can initiate at FED (although I suspect they cannot and thus this option should not be possible to select...I can modify code if needed for that case.)