### PR TITLE
reseed db only occurs in dev mode now

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -2,13 +2,17 @@ from typing import NamedTuple
 import click
 from flask.cli import with_appcontext
 from flask import current_app, g
-from config import db
+from config import db, flask_app
 import json
 
 from initial_data.init_office_table import init_office_table
-from initial_data.init_user_table import init_user_table_state_users, init_user_table_fed_users
+from initial_data.init_user_table import (
+    init_user_table_state_users,
+    init_user_table_fed_users,
+)
 from initial_data.init_status_table import init_status_table
 from initial_data.init_orders_table import init_orders_table
+
 
 def close_db(e=None):
     db = g.pop("db", None)
@@ -38,8 +42,12 @@ def init_db():
     init_user_table_fed_users(users_list, db)
     # add flag statuses to status table
     init_status_table(statuses_list, db)
-    # initialize orders table with fake orders--REMOVE WHEN PRODUCTION READY
-    init_orders_table(office_codes_list, db)
+    # initialize orders table with fake orders if in dev mode
+    print("DB is in debug mode: " + str(flask_app.debug))
+    print("DB is in mode: " + str(flask_app.env))
+    if flask_app.env == "development":
+
+        init_orders_table(office_codes_list, db)
 
     db.session.commit()
 

--- a/initial_data/init_orders_table.py
+++ b/initial_data/init_orders_table.py
@@ -1,9 +1,18 @@
 import uuid
 import random
 
-#  for state_offices in office_codes_list:
-#         usa_state = state_offices["usa_state"]
-#         for office_code in state_offices["office_code"]:
+fakeUUIDs = [
+    "268bf202-5da5-44be-9709-017a0833c661",
+    "652f6df6-a320-4316-a758-103e10421866",
+    "605f5f4c-5110-418a-9b1a-1213ebe2c4ea",
+    "961feb08-9ea7-4bab-9e18-bd28153e34c1",
+    "7c99905f-2465-4af8-93ef-3f8f7c9037e9",
+    "940ce5a5-5104-489b-8dbe-ae1e5489aee6",
+    "9aecc08b-da42-443e-a6ff-afb03e199d38",
+    "75c54e18-d516-4162-b065-3159f5ac8337",
+    "efe605ad-6429-4e02-8501-35156186fca3",
+    "adede23c-e1b1-4c1f-b76b-94eef91d4331",
+]
 
 
 def init_orders_table(office_codes_list, db):
@@ -12,11 +21,22 @@ def init_orders_table(office_codes_list, db):
 
     for x in range(10):
         order_number = x + 1
-        theUuid = str(uuid.uuid4())
-        usa_state_object = random.choice(office_codes_list)
+
+        # To come back to this. Desired behavior is to create randomized orders if the app is being tested, but non-randomized orders if the app is being developed.
+        #     theUuid = str(uuid.uuid4())
+        #     usa_state_object = random.choice(office_codes_list)
+        #     usa_state = usa_state_object.get("usa_state")
+        #     order_status = random.randint(1, 10)
+        #     home_office_code = random.choice(usa_state_object.get("office_code"))
+
+        theUuid = fakeUUIDs[x]
+        usa_state_object = office_codes_list[x + x + 2]
         usa_state = usa_state_object.get("usa_state")
-        order_status = random.randint(1, 10)
-        home_office_code = random.choice(usa_state_object.get("office_code"))
+        if x > 0 and x <= 9:
+            order_status = x
+        else:
+            order_status = 1
+        home_office_code = usa_state_object.get("office_code")[0]
 
         order_ = OrderModel(
             theUuid, usa_state, order_number, home_office_code, order_status

--- a/restart.sh
+++ b/restart.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 rm -rf migrations
 rm flag*.db
-DEBUG=True FLASK_APP=app.py flask db init
-DEBUG=True FLASK_APP=app.py flask db migrate
-DEBUG=True FLASK_APP=app.py flask db upgrade
-DEBUG=True FLASK_APP=app.py flask init-db
+DEBUG=True FLASK_ENV=development FLASK_APP=app.py flask db init
+DEBUG=True FLASK_ENV=development FLASK_APP=app.py flask db migrate
+DEBUG=True FLASK_ENV=development FLASK_APP=app.py flask db upgrade
+DEBUG=True FLASK_ENV=development FLASK_APP=app.py flask init-db
 cp flag.db flagtests.db


### PR DESCRIPTION
Oddly, the hardest part of this was to actually get flask to recognize when it is in development mode.

The commands we have in restart.sh ("DEBUG=True FLASK_APP=app.py flask init-db") do not actually do this. I set init_db to print the value of flask_app.debug, and it prints false, unless FLASK_ENV=development is also set in the shell script. Modifying those lines causes debug to become true and development mode to be turned on.

I spent a little time researching why this might be but was unable to discover the answer. I assume the answer is "these settings only work in tandem, just because" but there may be something else going on?