### PR TITLE
DC-01 does not exist, admin accounts are also pre-populated

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -5,6 +5,5 @@
  {"username":"FED-ADMIN","password":"FED-ADMIN-1010","office_code":"FED-ADMIN","can_create_update_delete_orders":"Y","can_update_status_for":"ALL","can_update_password_for":"ALL","is_admin":"Y"},
  {"username":"FLAG","password":"FLAG-1010","office_code":"FED-ADMIN","can_create_update_delete_orders":"N","can_update_status_for":"NONE","can_update_password_for":"NONE","is_admin":"N"},
  {"username":"MA-01","password":"MA-01-1010","office_code":"MA-01","can_create_update_delete_orders":"N","can_update_status_for":"MA-01","can_update_password_for":"NONE","is_admin":"N"},
- {"username":"DC-01-ADMIN","password":"DC-01-ADMIN-1010","office_code":"DC-01","can_create_update_delete_orders":"Y","can_update_status_for":"ALL","can_update_password_for":"DC-01","is_admin":"N"},
  {"username":"MA-01-READONLY","password":"MA-01-READONLY-1010","office_code":"MA-01","can_create_update_delete_orders":"N","can_update_status_for":"NONE","can_update_password_for":"NONE","is_admin":"N"}
 ]


### PR DESCRIPTION
(thad comment: Merrett and I updated heroku today and discovered that this tweak was needed to get the populate script working again and passing the constraints, since DC-01 is not a real office)