### PR TITLE
Change populate order to update for each status

### DIFF
--- a/data/scripts/add_stable_orders.py
+++ b/data/scripts/add_stable_orders.py
@@ -1,6 +1,11 @@
 import uuid
 import random
 
+from src.order.order_actions import OrderActions
+from data.scripts.data_util import get_office_codes_list
+
+office_codes_list = get_office_codes_list()
+
 fakeUUIDs = [
     "268bf202-5da5-44be-9709-017a0833c661",
     "652f6df6-a320-4316-a758-103e10421866",
@@ -17,10 +22,13 @@ fakeUUIDs = [
 
 def add_stable_orders(office_codes_list, db):
 
-    print("Adding sample orders (stable)");
+    print("Adding sample orders (stable)")
 
     from src.order.order_model import OrderModel
+    from src.order_log.order_log_model import OrderLogModel
 
+    OrderLogModel.query.delete()
+    OrderModel.query.delete()
     for x in range(10):
         order_number = x + 1
 
@@ -41,9 +49,15 @@ def add_stable_orders(office_codes_list, db):
             order_status_id = 1
         home_office_code = usa_state_object.get("office_code")[0]
 
-        order_ = OrderModel(
-            theUuid, usa_state, order_number, home_office_code, order_status_id
+        # order_ = OrderModel(
+        #     theUuid, usa_state, order_number, home_office_code, order_status_id
+        # )
+        OrderActions.create(
+            uuid_param=theUuid,
+            usa_state=usa_state,
+            order_number=order_number,
+            home_office_code=home_office_code,
+            order_status_id=order_status_id,
         )
-        db.session.add(order_)
-    
+
     db.session.commit()

--- a/data/scripts/add_stable_orders.py
+++ b/data/scripts/add_stable_orders.py
@@ -3,6 +3,8 @@ import random
 
 from src.order.order_actions import OrderActions
 from data.scripts.data_util import get_office_codes_list
+from src.status.status_actions import StatusActions
+from src.status.status_model import StatusModel
 
 office_codes_list = get_office_codes_list()
 
@@ -29,6 +31,8 @@ def add_stable_orders(office_codes_list, db):
 
     OrderLogModel.query.delete()
     OrderModel.query.delete()
+    statuses = StatusActions.get_sorted_statuses()
+    print("debug status 2", statuses)
     for x in range(10):
         order_number = x + 1
 
@@ -43,10 +47,6 @@ def add_stable_orders(office_codes_list, db):
         usa_state_object = office_codes_list[x + x + 2]
         usa_state = usa_state_object.get("usa_state")
 
-        if x > 0 and x <= 9:
-            order_status_id = x
-        else:
-            order_status_id = 1
         home_office_code = usa_state_object.get("office_code")[0]
 
         # order_ = OrderModel(
@@ -57,7 +57,14 @@ def add_stable_orders(office_codes_list, db):
             usa_state=usa_state,
             order_number=order_number,
             home_office_code=home_office_code,
-            order_status_id=order_status_id,
+            order_status_id=statuses[0].id,
         )
+        if x > 0 and x < len(statuses):
+            for status_position in range(1, x + 1):
+                order_status_id = statuses[status_position].id
+                OrderActions.update_order_by_uuid(
+                    theUuid, order_status_id=order_status_id
+                )
+                print("debug updated to", order_status_id)
 
     db.session.commit()

--- a/data/scripts/data_util.py
+++ b/data/scripts/data_util.py
@@ -1,0 +1,9 @@
+import json
+
+
+def get_office_codes_list():
+    with open(
+        "data/office_codes.json",
+    ) as office_codes_json:
+        office_codes_list = json.load(office_codes_json)
+    return office_codes_list

--- a/populate_seed_data.py
+++ b/populate_seed_data.py
@@ -22,6 +22,7 @@ if users_exist:
     sys.exit()
 office_codes_list = get_office_codes_list()
 
+
 with open("data/fed_users_order_privs.json") as users_json:
     users_list = json.load(users_json)
 

--- a/populate_seed_data.py
+++ b/populate_seed_data.py
@@ -1,16 +1,18 @@
 import json
 import sys
+from webbrowser import get
 from dotenv import load_dotenv
+
 load_dotenv()
 
 
 from config import db
 from src.user.user_model import UserModel
+from data.scripts.data_util import get_office_codes_list
 from data.scripts.add_offices import add_offices
 from data.scripts.add_stable_orders import add_stable_orders
 from data.scripts.add_statuses import add_statuses
 from data.scripts.add_users import add_fed_users, add_state_office_users
-
 
 
 users = db.session.query(UserModel).all()
@@ -18,10 +20,7 @@ users_exist = users and len(users) > 0
 if users_exist:
     print("Seed data has already been populated.")
     sys.exit()
-with open(
-        "data/office_codes.json",
-) as office_codes_json:
-    office_codes_list = json.load(office_codes_json)
+office_codes_list = get_office_codes_list()
 
 with open("data/fed_users_order_privs.json") as users_json:
     users_list = json.load(users_json)

--- a/setup/run.sh
+++ b/setup/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-FLASK_APP=app.py FLASK_ENV=development flask run
+DEBUG=True FLASK_APP=app.py FLASK_ENV=development flask run

--- a/src/order/order_actions.py
+++ b/src/order/order_actions.py
@@ -23,8 +23,9 @@ class OrderActions:
         home_office_code: str,
         order_status_id: int = None,
         order_status: OrderModel = None,
+        uuid_param: str = None,
     ):
-        theUuid = str(uuid.uuid4())
+        theUuid = uuid_param or str(uuid.uuid4())
         new_order = OrderModel(
             theUuid,
             usa_state,

--- a/src/order/order_actions.py
+++ b/src/order/order_actions.py
@@ -89,7 +89,11 @@ class OrderActions:
         order.home_office_code = home_office_code or order.home_office_code
         order.order_status_id = order_status_id or order.order_status_id
         LogActions.create_order_log(
-            uuid, usa_state, order_number, home_office_code, order_status_id
+            uuid,
+            order.usa_state,
+            order.order_number,
+            order.home_office_code,
+            order.order_status_id,
         )
         db.session.commit()
         return order

--- a/src/order/order_controller.py
+++ b/src/order/order_controller.py
@@ -1,4 +1,8 @@
+import os
 from flask import render_template, request, send_file, Response
+from data.scripts.add_stable_orders import add_stable_orders
+from werkzeug.exceptions import Unauthorized
+from data.scripts.data_util import get_office_codes_list
 from src.order_log import order_log_controller
 from src.util import table_record_to_json, get_dict_keyvalue_or_default, table_to_json
 from config import flask_app, qrcode, db
@@ -209,3 +213,13 @@ def get_orders_by_order_status_id(order_status_id):
     status_jason = [table_record_to_json(status) for status in statuses]
     add_mock_constituents(status_jason)
     return {"orders": status_jason}
+
+
+def reset():
+    flask_env = os.environ["FLASK_ENV"]
+    if not (flask_env == "development" or flask_env == "test"):
+        raise Unauthorized("reset not allowed for FLASK_ENV " + flask_env)
+    office_codes_list = get_office_codes_list()
+    add_stable_orders(office_codes_list=office_codes_list, db=db)
+    print("Reset data")
+    return {"reset": "success"}

--- a/src/routes.py
+++ b/src/routes.py
@@ -11,11 +11,16 @@ from src.order_log import order_log_controller
 
 routes = [
     ["/api", order_controller.index, "GET"],
+    ["/api/reset", order_controller.reset, "GET"],
     ["/api/orders/create", order_controller.create_order, "POST"],
     ["/api/orders", order_controller.get_orders, "GET"],
     ["/api/orders/<uuid>", order_controller.get_order_by_uuid, "GET"],
     ["/api/orders/<uuid>", order_controller.delete_order_by_uuid, "DELETE"],
-    ["/api/order_num/<order_number>", order_controller.get_order_by_order_number, "GET"],
+    [
+        "/api/order_num/<order_number>",
+        order_controller.get_order_by_order_number,
+        "GET",
+    ],
     ["/api/info", WebController.info, "GET"],
     ["/api/orders/<uuid>", order_controller.update_order, "PUT"],
     ["/api/scan/<uuid>", order_controller.update_order_status, "PUT"],
@@ -26,10 +31,14 @@ routes = [
     ["/api/state_offices/<state>", office_controller.get_offices_by_state, "GET"],
     ["/api/statuses", status_controller.get_statuses, "GET"],
     ["/api/users/create", user_controller.create_user, "POST"],
-    ["/api/users/self/update/password",user_controller.self_update_password,"POST"],
-    ["/api/users/admin/update/password",user_controller.admin_update_password,"POST"],
+    ["/api/users/self/update/password", user_controller.self_update_password, "POST"],
+    ["/api/users/admin/update/password", user_controller.admin_update_password, "POST"],
     ["/api/orders/logs", order_log_controller.get_order_logs, "GET"],
-    ["/api/orders/logs/<order_number>", order_log_controller.get_all_order_logs_by_order_number, "GET"],
+    [
+        "/api/orders/logs/<order_number>",
+        order_log_controller.get_all_order_logs_by_order_number,
+        "GET",
+    ],
 ]
 
 for route in routes:

--- a/src/status/status_actions.py
+++ b/src/status/status_actions.py
@@ -9,5 +9,7 @@ class StatusActions:
     # Table actions:
 
     @classmethod
-    def get_statuses(cls):
-        return StatusModel.query.all()
+    def get_sorted_statuses(cls):
+        statuses = StatusModel.query.all()
+        statuses.sort(key=lambda status: status.sequence_num)
+        return statuses

--- a/src/status/status_controller.py
+++ b/src/status/status_controller.py
@@ -9,5 +9,5 @@ from src.auth import auth_controller
 
 def get_statuses():
     auth_controller.set_authorize_current_user()
-    statuses = StatusActions.get_statuses()
+    statuses = StatusActions.get_sorted_statuses()
     return {"statuses": [table_record_to_json(status) for status in statuses]}

--- a/tests/actions/test_order_actions.py
+++ b/tests/actions/test_order_actions.py
@@ -11,7 +11,7 @@ from src.order.order_model import OrderModel
 class TestOrderActions:
     def test_create(self):
         unique_order_number = random.randint(1, 1000000)
-        expected_status: StatusModel = StatusActions.get_statuses()[0]
+        expected_status: StatusModel = StatusActions.get_sorted_statuses()[0]
         status_id = expected_status.id
         OrderActions.create(
             usa_state="MD",

--- a/tests/controller/test_order_controller.py
+++ b/tests/controller/test_order_controller.py
@@ -11,66 +11,77 @@ import pytest
 from src.util import table_record_to_json
 
 
-class TestOrderController():
-
+class TestOrderController:
     def test_controllers_get_order_by_uuid(self, mocker):
         # TODO refactor this to auth_controller.__name__
-        mocker.patch.object(order_controller, "auth_controller",  #auth_controller.__name__,
-                            tests.mock_auth_controller)
-        mocker.patch.object(order_controller, "auth_privileges",  #auth_controller.__name__,
-                            tests.mock_auth_privileges)
+        mocker.patch.object(
+            order_controller,
+            "auth_controller",  # auth_controller.__name__,
+            tests.mock_auth_controller,
+        )
+        mocker.patch.object(
+            order_controller,
+            "auth_privileges",  # auth_controller.__name__,
+            tests.mock_auth_privileges,
+        )
         unique_order_number = random.randint(1, 1000000)
         created_order = OrderActions.create("OH", unique_order_number, "OH06")
         actual_order = order_controller.get_order_by_uuid(created_order.uuid)
 
-        assert (actual_order['usa_state'] == "OH")
-        assert (actual_order['home_office_code'] == "OH06")
-        assert (actual_order['order_number'] == str(unique_order_number))
-        assert (actual_order['uuid'] == created_order.uuid)
+        assert actual_order["usa_state"] == "OH"
+        assert actual_order["home_office_code"] == "OH06"
+        assert actual_order["order_number"] == str(unique_order_number)
+        assert actual_order["uuid"] == created_order.uuid
 
     # @pytest.mark.skip(reason="Test fails because not mocked properly, skipping until fixed")
     def test_create_update_order(self, mocker):
 
-        mocker.patch.object(order_controller, 'request', mock_request)
+        mocker.patch.object(order_controller, "request", mock_request)
         # TODO refactor this to auth_controller.__name__
-        mocker.patch.object(order_controller, "auth_controller",  #auth_controller.__name__,
-                            tests.mock_auth_controller)
-        mocker.patch.object(order_controller, "auth_privileges", tests.mock_auth_privileges)
+        mocker.patch.object(
+            order_controller,
+            "auth_controller",  # auth_controller.__name__,
+            tests.mock_auth_controller,
+        )
+        mocker.patch.object(
+            order_controller, "auth_privileges", tests.mock_auth_privileges
+        )
 
         unique_order_number = random.randint(1, 100000000)
-        status = StatusActions.get_statuses()[2]
-        order_request_json = {"usa_state": "OH", "home_office_code": "OH06",
-                              "order_number": unique_order_number, "order_status_id":status.id}
-        mock_request.mock_request_json = order_request_json;
-
+        status = StatusActions.get_sorted_statuses()[2]
+        order_request_json = {
+            "usa_state": "OH",
+            "home_office_code": "OH06",
+            "order_number": unique_order_number,
+            "order_status_id": status.id,
+        }
+        mock_request.mock_request_json = order_request_json
 
         response = order_controller.create_order()
 
         TestOrderController.assertExpectedOrder(order_request_json, response, status)
 
-        status = StatusActions.get_statuses()[2]
-        order_request_json = {"usa_state": "MA", "home_office_code": "MA06",
-                              "order_number": unique_order_number+1, "order_status_id":status.id}
-        mock_request.mock_request_json = order_request_json;
+        status = StatusActions.get_sorted_statuses()[2]
+        order_request_json = {
+            "usa_state": "MA",
+            "home_office_code": "MA06",
+            "order_number": unique_order_number + 1,
+            "order_status_id": status.id,
+        }
+        mock_request.mock_request_json = order_request_json
 
-        response = order_controller.update_order(uuid=response['uuid'])
+        response = order_controller.update_order(uuid=response["uuid"])
 
         TestOrderController.assertExpectedOrder(order_request_json, response, status)
 
-
     @staticmethod
     def assertExpectedOrder(order_request_json, response, status):
-        assert (response['usa_state'] == order_request_json['usa_state'])
-        assert (response['home_office_code'] == order_request_json['home_office_code'])
-        assert (response['order_number'] == str(order_request_json['order_number']))
-        assert (response['status']['description']) == status.description;
-        order = OrderActions.get_order_by_uuid(response['uuid']);
-        assert (order.usa_state == order_request_json['usa_state'])
-        assert (order.home_office_code == order_request_json['home_office_code'])
-        assert (order.order_number == order_request_json['order_number'])
-        assert (order.status.description) == status.description;
-
-
-
-
-
+        assert response["usa_state"] == order_request_json["usa_state"]
+        assert response["home_office_code"] == order_request_json["home_office_code"]
+        assert response["order_number"] == str(order_request_json["order_number"])
+        assert (response["status"]["description"]) == status.description
+        order = OrderActions.get_order_by_uuid(response["uuid"])
+        assert order.usa_state == order_request_json["usa_state"]
+        assert order.home_office_code == order_request_json["home_office_code"]
+        assert order.order_number == order_request_json["order_number"]
+        assert (order.status.description) == status.description

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 import random
 
 import pytest
+
 # qrcode related imports
 
 # import cv2
@@ -22,21 +23,27 @@ from src.order.order_model import OrderModel
 from src.util import table_record_to_json
 
 
-class TestUtils():
+class TestUtils:
     def test_table_record_to_json(self):
         unique_number = random.randint(1, 1000000)
         order_number = unique_number
         usa_state = "MA"
-        order_statuses: [StatusModel] = StatusActions.get_statuses()
+        order_statuses: [StatusModel] = StatusActions.get_sorted_statuses()
         order_status = order_statuses[0]
         home_office_code = "FED-ADMIN"
-        order = OrderActions.create(order_number=order_number, usa_state=usa_state,
-                                    home_office_code=home_office_code, order_status=order_status)
+        order = OrderActions.create(
+            order_number=order_number,
+            usa_state=usa_state,
+            home_office_code=home_office_code,
+            order_status=order_status,
+        )
         json = table_record_to_json(order)
-        assert (json["usa_state"] == order.usa_state)
-        assert (json["status"]["description"] == order_status.description)
+        assert json["usa_state"] == order.usa_state
+        assert json["status"]["description"] == order_status.description
 
-    @pytest.mark.skip(reason="function works, but test does not.  openCV is an issue, so may delete this test.")
+    @pytest.mark.skip(
+        reason="function works, but test does not.  openCV is an issue, so may delete this test."
+    )
     def test_qrcode(self):
         qrcodeValue = "https://example.com/A43X2Q3"
         # with app.test_client() as c:


### PR DESCRIPTION
Rather than create an order with a specific status, create order and then update the order sequentially through statuses until it reaches desired status.